### PR TITLE
Created a read_SOCAT function that reads the SOCAT file and outputs the metadata and data frames and the line numbers of the start/end of each, and adjust the GCBoverview_script.py accordingly.

### DIFF
--- a/GCBoverview_script.py
+++ b/GCBoverview_script.py
@@ -29,20 +29,26 @@ Maren Kjos Karlsen 2020-07-08
 
 import pandas as pd
 import datetime as dt
+import SOCAT_functions as SOCATf
 
-# Global variables, end of header and start of data will change from year to year
-FILE ='SOCATv2020.tsv'
-END_OF_METADATA=4
-END_OF_HEADER=6301
-START_OF_DATA=6363
-YEAR = '2019'
-
-# To minimize memory-issues only the expocode and datetime information is fetched from the file
+# # Global variables, end of header and start of data will change from year to year
+# FILE ='SOCATv2020.tsv'
+#END_OF_METADATA=4
+#END_OF_HEADER=6301
+# START_OF_DATA=6363
+YEAR = '2021'
+#
+# # To minimize memory-issues only the expocode and datetime information is fetched from the file
 EXP_DATETIME_COLUMNS = [0,4,5,6,7,8,9] #[Expocode,yr,mon,day,hh,mm,ss]
-
+FILE = '/Users/rocio/Downloads/SOCATv2022_synthesis_files/SOCATv2022.tsv'
 
 ### Extracting data content
-dd  = pd.read_csv(FILE, sep='\t', skiprows=START_OF_DATA,dtype=str,usecols=EXP_DATETIME_COLUMNS)
+
+# Maren set up the data types to be all read as string (the default is 0,2 str, rest float)
+# Change in the future?
+dd, df, _, _, _ = SOCATf.read_SOCAT(FILE, 'str')
+
+dd=dd.iloc[:,EXP_DATETIME_COLUMNS]
 print(dd.columns)
 
 ## Reduce dataframe to entries from YEAR (Use only 2019 data)   
@@ -70,8 +76,8 @@ days_per_cruise = num_per_days.groupby(['Expocode']).count()
 
 
 ### Extracting list of datasets
-df = pd.read_csv(FILE, sep='\t', dtype=str, skiprows=END_OF_METADATA, nrows=END_OF_HEADER)
-print(df.columns)
+#df = pd.read_csv(FILE, sep='\t', dtype=str, skiprows=END_OF_METADATA, nrows=END_OF_HEADER)
+#print(df.columns)
 
 # The Start/End time below is the leave/arrive at port date. These do not contain any time-information. 
 # These dates are used to extract cruises starting and/or ending in 2019. They will not be part of the final list. 
@@ -84,7 +90,7 @@ df['End year']=df['End Time'].dt.year
 print(df.columns)
 
 # Reducing dataframe to 2019-data only
-df = df.loc[(df['Start year'] == YEAR) | (df['End year'] == YEAR)]
+df = df.loc[(df['Start year'] == int(YEAR)) | (df['End year'] == int(YEAR))]
 df = df.drop(['Start year','Start Time','End year','End Time','Dataset Name','version'],axis=1) 
 
 

--- a/SOCAT_functions.py
+++ b/SOCAT_functions.py
@@ -1,0 +1,42 @@
+def read_SOCAT(filepath, ddtype={0: str, 2: str}):
+    import pandas as pd
+
+    SOCATmetacolheadertextshort = 'Expocode\tversion\tDataset'
+    SOCATcolheadertextshort = 'Expocode\tversion\tSource_DOI\tQC_Flag'
+
+    separator = '\t'
+    line = ''
+    start_data_line = -1
+    metaline = ''
+    start_metadata_line = -1
+    f = open(filepath)
+
+    while SOCATmetacolheadertextshort not in metaline:
+        metaline = f.readline()
+        start_metadata_line = start_metadata_line + 1  # Where metadata lines start
+
+    end_metadata_line = start_metadata_line
+    while '\t' in metaline:
+        metaline = f.readline()
+        end_metadata_line = end_metadata_line + 1  # End of metadata lines
+
+    # Create metadata dataframe
+    SOCAT_metadata = pd.read_csv(filepath, sep='\t',
+                                 skiprows=start_metadata_line,
+                                 nrows=end_metadata_line - start_metadata_line - 1,
+                                 dtype=ddtype)
+
+    # Find where data columns start
+    start_data_line = start_data_line + end_metadata_line
+    while SOCATcolheadertextshort not in line:
+        line = f.readline()
+        start_data_line = start_data_line + 1
+    f.close()
+
+    # Read SOCAT data in dataframe
+    #ddtype = {0: str, 2: str}  # add type str to columns 0 and 2
+    # Read the SOCAT file into a pandas dataframe
+    SOCAT_data = pd.read_csv(filepath, sep=separator, skiprows=start_data_line,
+                             na_values='NaN', on_bad_lines='skip', dtype=ddtype)
+
+    return SOCAT_data, SOCAT_metadata, start_metadata_line, end_metadata_line, start_data_line

--- a/platform_type.py
+++ b/platform_type.py
@@ -3,10 +3,11 @@ Fetches unique platforms and associated platform type from GCB 2018 and writes t
 
 Maren Kjos Karlsen 2020.07.06
 """
+# Better to use the CMEMS summary file or the platform one. It's more complete
 
 import pandas as pd
 
-df = pd.read_csv('2019/GCB2018_Datasets.csv',usecols=['Platform','Platform type','Expocode'])
+df = pd.read_csv('/Users/rocio/Downloads/GCB2019_Datasets.csv',usecols=['Platform','Platform type','Expocode'])
 
 df['Prefix'] = df['Expocode'].str[0:4]
 

--- a/regions.py
+++ b/regions.py
@@ -7,35 +7,46 @@ import os
 import pandas as pd
 import csv
 import re
+import SOCAT_functions as SOCATf
+SOCAT_synthesis_folder='/Users/rocio/Downloads/SOCATv2022_synthesis_files/'
+YEAR = '2021'
+#
+# # To minimize memory-issues only the expocode and datetime information is fetched from the file
+EXP_DATETIME_COLUMNS = [0,4,5,6,7,8,9] #[Expocode,yr,mon,day,hh,mm,ss]
+FILE = SOCAT_synthesis_folder+'SOCATv2022.tsv'
+_, df, _, _, _ = SOCATf.read_SOCAT(FILE,'str')
 
-FILE ='SOCATv2020.tsv'
-END_OF_METADATA=4
-END_OF_HEADER=6301
-START_OF_DATA=6363
+df=df['Expocode']
 
-df = pd.read_csv(FILE, sep='\t',skiprows=END_OF_METADATA, nrows=END_OF_HEADER,dtype=str,usecols=['Expocode'])
 expocodes = df.values
 
-all_files = os.listdir('.')
-regional_files = list(filter(lambda file: 'SOCATv2020_' in file, all_files))
+all_files = os.listdir(SOCAT_synthesis_folder)
+all_files=[SOCAT_synthesis_folder+f for f in all_files]
+regional_files = list(filter(lambda file: SOCAT_synthesis_folder+'SOCATv2022_' in file, all_files))
 
 regions={}
 for reg_file in regional_files:
   region_camelcase = reg_file.split('_')[-1].split('.')[0]
+  if region_camelcase =='FlagE': continue
   splitted = re.sub('([A-Z][a-z]+)', r' \1', re.sub('([A-Z]+)', r' \1', region_camelcase)).split()
   region = ' '.join(splitted)
-
 
   print(region)
 
   with open(reg_file) as file:
     content = file.read()
     for exp in expocodes:
-      if(exp[0] in content):
-        if exp[0] in regions.keys():
-          regions[exp[0]]+= '; ' + region
+      if(exp in content):
+        if exp in regions.keys():
+          regions[exp]+= '; ' + region
         else:
-          regions[exp[0]]=region
+          regions[exp]=region
+
+      # if(exp[0] in content):
+      #   if exp[0] in regions.keys():
+      #     regions[exp[0]]+= '; ' + region
+      #   else:
+      #     regions[exp[0]]=region
 
 print(regions)
 


### PR DESCRIPTION
regions.py for some reason exp[0] did not work (it took only the first character of the expocode).
Changed paths.
Potential improvements:
- Read data file as strings or numbers? Datetime shenanigans.
- read_SOCAT function: if loop for reading and creating the SOCAT data dataframe (the most time consuming part). It requires that the function knows whether that output is requested.
- regions.py: takes a long time, probably from reading the whole files, when temptatively the metadata dataframe would suffice (hence the improvement above)
- platform_type.py: use something else as data source (CMEMS summary? Platform sheet?)
